### PR TITLE
Fix parse access_key when auth header blank

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ signature.headers
 Validate the request on the client-side. Note, that access_key can be extracted from the request.
 
 ```ruby
+# the request to validate
 request = {
   :http_method=>"POST",
   :url=>"https://example.com/posts",
@@ -71,11 +72,14 @@ request = {
 # initialize validator with a request to validate
 validator = ApiSignature::Validator.new(request)
 
-# get access key from request headers
+# get access key from request headers (String)
 validator.access_key
 
-# validate the request
+# validate the request (Boolean)
 validator.valid?('your secret key here')
+
+# get only signed headers (Hash)
+validator.signed_headers
 ```
 
 ## Configuration

--- a/lib/api_signature/validator.rb
+++ b/lib/api_signature/validator.rb
@@ -27,6 +27,8 @@ module ApiSignature
     end
 
     def access_key
+      return unless valid_credential?
+
       @access_key ||= auth_header.credential.split('/')[0]
     end
 
@@ -45,7 +47,11 @@ module ApiSignature
     end
 
     def valid_authorization?
-      !auth_header.credential.nil? && !auth_header.signature.nil?
+      valid_credential? && !auth_header.signature.nil?
+    end
+
+    def valid_credential?
+      !auth_header.credential.nil?
     end
 
     def valid_timestamp?

--- a/spec/api_signature/validator_spec.rb
+++ b/spec/api_signature/validator_spec.rb
@@ -141,4 +141,18 @@ RSpec.describe ApiSignature::Validator do
       expect(validator.valid?(secret_key)).to eq false
     end
   end
+
+  context 'when empty authorization header' do
+    let(:request_to_validate) do
+      request_to_sign
+    end
+
+    it 'must return blank access_key' do
+      expect(validator.access_key).to eq nil
+    end
+
+    it 'must return blank signed headers' do
+      expect(validator.signed_headers).to eq({})
+    end
+  end
 end

--- a/spec/api_signature/validator_spec.rb
+++ b/spec/api_signature/validator_spec.rb
@@ -154,5 +154,9 @@ RSpec.describe ApiSignature::Validator do
     it 'must return blank signed headers' do
       expect(validator.signed_headers).to eq({})
     end
+
+    it 'must not be valid' do
+      expect(validator.valid?(secret_key)).to eq false
+    end
   end
 end


### PR DESCRIPTION
Fix parse access_key when auth header blank